### PR TITLE
Installation and callback fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ the `winType` when creating a new window.
 Creating a window using GLFW as the backend::
 
     import psychopy.visual as visual
-    win = visual.Window(winType='gflw')
+    win = visual.Window(winType='glfw')

--- a/psychopy_glfw/glfwbackend.py
+++ b/psychopy_glfw/glfwbackend.py
@@ -523,8 +523,11 @@ class GLFWBackend(BaseBackend):
         """
         pass
 
-    def onResize(self, width, height):
+    def onResize(self, glfw_handle, width, height):
         _onResize(width, height)
+
+    def onMove(self, glfw_handle, posX, posY):
+        super().onMove(posX, posY)
 
     @attributeSetter
     def gamma(self, gamma):

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     name=name,  # set the name
     version=version,  # put your plugin version here
     packages=packages,
+    install_requires=['glfw'],
     package_dir=package_dir,
     package_data=package_data,
     author="Matthew D. Cutone",


### PR DESCRIPTION
Just a few little things. The glfw package wasn't included as a dependency, and some of the callbacks also receive the GLFW window as an argument, which led to errors when those callbacks were invoked.